### PR TITLE
Replace azure/arm-deploy@v2 with Azure CLI

### DIFF
--- a/.github/workflows/eshoponweb-cicd.yml
+++ b/.github/workflows/eshoponweb-cicd.yml
@@ -5,11 +5,11 @@ on: workflow_dispatch
 
 #Environment variables https://docs.github.com/en/actions/learn-github-actions/environment-variables
 env:
-  RESOURCE-GROUP: rg-eshoponweb-westeurope
+  RESOURCE-GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
   LOCATION: westeurope
   TEMPLATE-FILE: infra/webapp.bicep
   SUBSCRIPTION-ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-  WEBAPP-NAME: devops-webapp-westeurope-178376703
+  WEBAPP-NAME: ${{ secrets.AZURE_WEBAPP_NAME }}
 
 
 jobs:
@@ -78,14 +78,29 @@ jobs:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
            
     # Deploy Azure WebApp using Bicep file
-    - name: deploy
-      uses: azure/arm-deploy@v2
+    - name: Deploy infrastructure
+      uses: Azure/cli@v2
       with:
-        subscriptionId: ${{ env.SUBSCRIPTION-ID }}
-        resourceGroupName: ${{ env.RESOURCE-GROUP }}
-        template: bicep-template/webapp.bicep
-        parameters: 'webAppName=${{ env.WEBAPP-NAME }} location=${{ env.LOCATION }}'
-        failOnStdErr: false   
+        inlineScript: |
+          az deployment group create \
+            --name webapp-deployment-${{ github.run_number }} \
+            --resource-group ${{ env.RESOURCE-GROUP }} \
+            --template-file bicep-template/webapp.bicep \
+            --parameters webAppName=${{ env.WEBAPP-NAME }} location=${{ env.LOCATION }} \
+            --output json
+    
+    # Get the Web App Name from deployment output
+    - name: Get WebApp Details
+      id: webapp
+      uses: Azure/cli@v2
+      with:
+        inlineScript: |
+          webAppName=$(az deployment group show \
+            --name webapp-deployment-${{ github.run_number }} \
+            --resource-group ${{ env.RESOURCE-GROUP }} \
+            --query 'properties.outputs.webAppName.value' \
+            --output tsv)
+          echo "webapp-name=$webAppName" >> $GITHUB_OUTPUT
     
     # Publish website to Azure App Service (WebApp)
     # Step disabled due to issue where the site sometimes can't be found: https://github.com/microsoft/pipelines-appservice-lib/issues/56. Instead deploy using CLI
@@ -102,4 +117,4 @@ jobs:
       uses: Azure/cli@v2
       with:
         inlineScript: |
-             az webapp deploy --name ${{ env.WEBAPP-NAME }} --resource-group ${{ env.RESOURCE-GROUP }} --src-path .net-app/app.zip --type zip
+             az webapp deploy --name ${{ steps.webapp.outputs.webapp-name }} --resource-group ${{ env.RESOURCE-GROUP }} --src-path .net-app/app.zip --type zip

--- a/infra/webapp.bicep
+++ b/infra/webapp.bicep
@@ -35,3 +35,7 @@ resource appService 'Microsoft.Web/sites@2022-09-01' = {
     }
   }
 }
+
+output webAppName string = appService.name
+output webAppUrl string = appService.properties.defaultHostName
+output resourceId string = appService.id


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow and the Bicep infrastructure template to improve deployment automation and security. The changes enhance the use of secrets for sensitive values, switch to a more flexible deployment approach using the Azure CLI, and add outputs to the Bicep template for better integration with the workflow.

**Workflow improvements and deployment automation:**

* Updated environment variables in `.github/workflows/eshoponweb-cicd.yml` to use GitHub secrets for `RESOURCE-GROUP` and `WEBAPP-NAME`, improving security and flexibility.
* Replaced the `azure/arm-deploy` action with `Azure/cli@v2` for infrastructure deployment, allowing for more customizable deployment logic via inline scripts.
* Added a step to retrieve the deployed Web App name from the Bicep deployment output, storing it for use in subsequent steps.
* Modified the web app deployment step to use the dynamically retrieved Web App name instead of a static environment variable, ensuring correct resource targeting.